### PR TITLE
Add texture filter and mipmapping fix

### DIFF
--- a/src/OGLTexture.cpp
+++ b/src/OGLTexture.cpp
@@ -123,10 +123,6 @@ void COGLTexture::EndUpdate(DrawInfo *di)
 #if SDL_VIDEO_OPENGL
         // Tell to hardware to generate mipmap (himself) when glTexImage2D is called
         glTexParameteri(GL_TEXTURE_2D, GL_GENERATE_MIPMAP, GL_TRUE);
-#elif SDL_VIDEO_OPENGL_ES2
-		//TODO test if this increases performance
-		//glHint(GL_FASTEST, GL_GENERATE_MIPMAP_HINT);
-        glGenerateMipmap(GL_TEXTURE_2D);
 #endif
         OPENGL_CHECK_ERRORS;
     }
@@ -143,6 +139,8 @@ void COGLTexture::EndUpdate(DrawInfo *di)
     //GL_BGRA_IMG works on adreno but not inside profiler.
     glTexImage2D(GL_TEXTURE_2D, 0, m_glFmt, m_dwCreatedTextureWidth, m_dwCreatedTextureHeight, 0, m_glFmt, GL_UNSIGNED_BYTE, m_pTexture);
     //fprintf(stderr, "glTexImage2d(m_glFmt=%X,  m_dwCreatedTextureWidth=%d, m_dwCreatedTextureHeight=%d\n", m_glFmt, m_dwCreatedTextureWidth, m_dwCreatedTextureHeight);
+    if(options.mipmapping)
+        glGenerateMipmap(GL_TEXTURE_2D);
 #endif
     OPENGL_CHECK_ERRORS;
 }

--- a/src/Render.cpp
+++ b/src/Render.cpp
@@ -315,6 +315,8 @@ void CRender::SetCombinerAndBlender()
         m_pAlphaBlender->InitBlenderMode();
 
     m_pColorCombiner->InitCombinerMode();
+    
+    ApplyTextureFilter();
 }
 
 void CRender::RenderReset()
@@ -1918,8 +1920,6 @@ void CRender::UpdateScissorWithClipRatio()
 // Set other modes not covered by color combiner or alpha blender
 void CRender::InitOtherModes(void)
 {
-    ApplyTextureFilter();
-
     //
     // I can't think why the hand in mario's menu screen is rendered with an opaque rendermode,
     // and no alpha threshold. We set the alpha reference to 1 to ensure that the transparent pixels


### PR DESCRIPTION
Shadows, water and some texture look pixelated at the moment. These two upstream fixes at texture filtering for all textures.
