### PR TITLE
Makefile: Add VC option so we can use this plugin on other platforms

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -125,11 +125,6 @@ CFLAGS += $(OPTFLAGS) $(WARNFLAGS) -ffast-math -fno-strict-aliasing -fvisibility
 CXXFLAGS += -fvisibility-inlines-hidden -DSDL_VIDEO_OPENGL_ES2=1 -DSDL_VIDEO_OPENGL=0
 LDFLAGS += $(SHARED)
 
-
-ifeq ("$(MACHINE)","armv6l")
-  VC=1
-endif
-
 ifeq ($(VC), 1)
   CFLAGS += -DARM -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
   CXXFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -127,10 +127,16 @@ LDFLAGS += $(SHARED)
 
 
 ifeq ("$(MACHINE)","armv6l")
-CFLAGS += -DARM -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
-CXXFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
-LDLIBS += -lm -L/opt/vc/lib -lGLESv2 -lEGL -lbcm_host
+  VC=1
 endif
+
+ifeq ($(VC), 1)
+  CFLAGS += -DARM -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
+  CXXFLAGS += -I/opt/vc/include -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux
+  LDLIBS += -lm -L/opt/vc/lib -lEGL -lbcm_host
+endif
+
+LDLIBS += -lGLESv2
 
 ifeq ($(CPU), X86)
   CFLAGS += -msse
@@ -395,6 +401,7 @@ targets:
 	@echo "    NO_ASM=1      == build without inline assembly code (x86 MMX/SSE)"
 	@echo "    APIDIR=path   == path to find Mupen64Plus Core headers"
 	@echo "    OPTFLAGS=flag == compiler optimization (default: -O3 -flto)"
+	@echo "    VC=1 	 == build against Broadcom Videocore GLESv2"
 	@echo "    WARNFLAGS=flag == compiler warning levels (default: -Wall)"
 	@echo "    PIC=(1|0)     == Force enable/disable of position independent code"
 	@echo "    POSTFIX=name  == String added to the name of the the build (default: '')"


### PR DESCRIPTION
Raspberry PI 2 is no longer "armv6l" (it is "armv7l"). An option is more flexible as a hard coded MACHINE test. So we can use this plugin on other broadcom platforms as well. I have not removed ("$(MACHINE)","armv6l") because it would break backward compatibility with your mupen64plus build script.
