### PR TITLE
Undefined min and max functions to prevent clash with system includes.

### DIFF
--- a/src/OGLES2FragmentShaders.h
+++ b/src/OGLES2FragmentShaders.h
@@ -16,6 +16,9 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 
+#undef min
+#undef max
+
 #ifndef _OGL_FRAGMENT_SHADER_H_
 #define _OGL_FRAGMENT_SHADER_H_
 


### PR DESCRIPTION
When compiling with GCC 6.1.1 under ArchLinux compilation fails due to a clash with already defined min/max functions in the system includes.

By undefining them compilation is able to proceed.
